### PR TITLE
Enable configuration for Apollo Client from the application State.

### DIFF
--- a/src/common/createKernel.js
+++ b/src/common/createKernel.js
@@ -31,9 +31,12 @@ export default function createKernel(State, { state = defaultState, edge, reques
     request ? request.path : null
   )
 
-  let apollo = createApolloClient({
-    uri: null
-  })
+  const apolloClientConfig =
+    State.getApolloClientConfig && State.getApolloClientConfig() ?
+      State.getApolloClientConfig() :
+      { uri: null }
+
+  let apollo = createApolloClient(apolloClientConfig)
 
   let store = createReduxStore({
     reducers: State.getReducers(),


### PR DESCRIPTION
There needs to be a way for the Application using Edge to set up the
Apollo Client. It seems to be a reasonable way to have a method on the
State object. It's optional so this change is backwards compatible.